### PR TITLE
Enhance CLI functionality to support environment variables from stdin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "envmcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "envmcp",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "bin": {
         "envmcp": "dist/cli.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "envmcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "envmcp",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "bin": {
         "envmcp": "dist/cli.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "envmcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "envmcp",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "bin": {
         "envmcp": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "envmcp",
+  "name": "envmcp-tonidy",
   "version": "0.2.2",
   "description": "A lightweight way to use environment variables in your Cursor MCP server definitions.",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "envmcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A lightweight way to use environment variables in your Cursor MCP server definitions.",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kdbx/envmcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A lightweight way to use environment variables in your Cursor MCP server definitions.",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "envmcp-tonidy",
+  "name": "@kdbx/envmcp",
   "version": "0.2.2",
   "description": "A lightweight way to use environment variables in your Cursor MCP server definitions.",
   "main": "dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,20 +1,23 @@
 #!/usr/bin/env node
 
-import { loadEnvironmentVariablesFromFile, executeCommand } from './index';
+import { loadEnvironmentVariablesFromFile, loadEnvironmentVariablesFromStdin, executeCommand } from './index';
 
 function printUsage() {
-  console.error('Usage: envmcp [--env-file <path>] <command> [args...]');
+  console.error('Usage: envmcp [--env-file <path>] [--env-stdin] <command> [args...]');
   console.error('\nOptions:');
   console.error('  -e, --env-file <path>     Specify a custom path to the environment file');
+  console.error('  --env-stdin               Read environment variables from stdin');
   console.error('\nArguments:');
   console.error('  <command>                 The command to execute');
   console.error('  [args...]                 Arguments for the command');
   console.error('\nNote: All options must precede the command.');
+  console.error('Note: --env-file and --env-stdin are mutually exclusive.');
 }
 
-function main() {
+async function main() {
   const argv = process.argv.slice(2);
   let customEnvFilePath: string | undefined = undefined;
+  let useStdin = false;
   let commandIndex = 0;
   let error = false;
 
@@ -27,6 +30,11 @@ function main() {
         error = true;
         break;
       }
+      if (useStdin) {
+        console.error('Error: --env-file and --env-stdin are mutually exclusive.');
+        error = true;
+        break;
+      }
       if (commandIndex + 1 >= argv.length || argv[commandIndex + 1].startsWith('-')) {
         console.error(`Error: ${arg} option requires a path.`);
         error = true;
@@ -34,6 +42,19 @@ function main() {
       }
       customEnvFilePath = argv[commandIndex + 1];
       commandIndex += 2;
+    } else if (arg === '--env-stdin') {
+      if (useStdin) {
+        console.error('Error: --env-stdin option specified more than once.');
+        error = true;
+        break;
+      }
+      if (customEnvFilePath !== undefined) {
+        console.error('Error: --env-file and --env-stdin are mutually exclusive.');
+        error = true;
+        break;
+      }
+      useStdin = true;
+      commandIndex += 1;
     } else {
       // First non-option argument marks the start of the command
       break;
@@ -53,8 +74,15 @@ function main() {
   const command = commandArgs[0];
   const actualArgsForCommand = commandArgs.slice(1);
 
-  // Load environment variables from .env.mcp file
-  if (!loadEnvironmentVariablesFromFile(customEnvFilePath)) {
+  // Load environment variables from .env.mcp file or stdin
+  let envLoaded = false;
+  if (useStdin) {
+    envLoaded = await loadEnvironmentVariablesFromStdin();
+  } else {
+    envLoaded = loadEnvironmentVariablesFromFile(customEnvFilePath);
+  }
+
+  if (!envLoaded) {
     process.exit(1);
   }
 


### PR DESCRIPTION
Hi @griffithsbs,

This PR includes:

- Introduced the `--env-stdin` option to read environment variables directly from stdin.
- Updated usage instructions to reflect the new option and clarify mutual exclusivity with `--env-file`.
- Added error handling for multiple `--env-stdin` specifications and conflicts with `--env-file`.
- Implemented tests to verify the new functionality and error conditions.

I need to add this parameter `--env-stdin`, so I can pipe it with another command.

```json
{
  "mcpServers": {
    "mcp1": {
      "command": "sh",
      "args": [
        "-c",
        "pa show mcp/n8n/env | npx -y envmcp --env-stdin node /Users/t/mcp/dist/mcp/index.js"
      ]
    }
  }
}
````

Any feedback?